### PR TITLE
feature: 🐣 JWT-based authentication 🐣

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ module
 coverage
 
 # artifacts generated from our CI process:
-whoa-rasa-webchat-index.js
+whoa-rasa-webchat-index*.js

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ module
 
 # Test files
 coverage
+
+# artifacts generated from our CI process:
+whoa-rasa-webchat-index.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:12.12.0
+
+RUN mkdir /rasa-webchat
+
+WORKDIR /rasa-webchat
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+ENTRYPOINT [ "sleep", "365d" ]

--- a/README.md
+++ b/README.md
@@ -3,35 +3,37 @@ $$ \Huge \color{ProcessBlue} WHO \space Academy's \space Customization \space of
     This former part of the documentation explains how integrate this fork with the WHO Academy front end. The remaining part of the documentation is mostly inherited from the original README (and includes the necessary modifications).
 </p>
 
-### How to Integrate This Fork With the WHO Academy Front End
-1. Locally Build the Artifacts Necessary to Run This Customized Library:
-    - have this source on you local
-    - make sure Docker (~ 23.0.5) is installed on your local
-    - in the root folder of the repository, execute:
-      ```
-      docker build --tag whoa-rasa-webchat .
-      docker run --name whoa-rasa-webchat --detach whoa-rasa-webchat
-      docker cp whoa-rasa-webchat:/rasa-webchat/lib/index.js whoa-rasa-webchat-index.js
-      ```
-    - optionally, just to clean your local, also execute in the same folder:
-      ```
-      docker rm -f whoa-rasa-webchat
-      docker rmi whoa-rasa-webchat
-      ```
-2. Upload Such Artifacts From Your Local to Our Azure File Storage Location:
-    - manually upload the newly generated (on your local directory) file `whoa-rasa-webchat-index.js` to our Azure Storage Account `whoalxppublicstorage` inside the container `machine-learning`
-3. Download the Artifacts on the Learner's Browser by Referencing Their URL in Our Front-End Source:
-    - modify the front-end source of our delivery website so that the widget of Rasa Webchat downloads its source from our Azure Storage Account, replacing the default URL that points to `cdn.jsdelivr.net` that you can see in the rest of this documentation, as this code snippet exemplifies:
-      ```diff
-      <script>!(function () {
-        ...
-        (e.src =
-      -    "https://cdn.jsdelivr.net/npm/rasa-webchat@1.x.x/lib/index.js"),
-      +    "https://whoalxppublicstorage.blob.core.windows.net/machine-learning/whoa-rasa-webchat-index.js"),
-        ...
-      })();
-      </script>
-      ```
+### How to Integrate This Fork With the WHO Academy's Front End
+1. #### Locally Build the Artifacts Necessary to Run This Customized Library:
+    1. have this source on you local
+    1. make sure Docker (~ 23.0.5) is installed on your local
+    1. make your code changes (if any)
+    1. in the root folder of the repository, execute:
+        ```
+        docker build --tag whoa-rasa-webchat .
+        docker run --name whoa-rasa-webchat --detach whoa-rasa-webchat
+        docker cp whoa-rasa-webchat:/rasa-webchat/lib/index.js whoa-rasa-webchat-index.js
+        ```
+    1. optionally, just to clean your local, also execute in the same folder:
+        ```
+        docker rm -f whoa-rasa-webchat
+        docker rmi whoa-rasa-webchat
+        ```
+1. #### Upload Such Artifacts From Your Local to Our Azure File Storage Location:
+    1. rename the newly generated (on your local directory) file `whoa-rasa-webchat-index.js` by adding a semantic version suffix to its filename, such as `whoa-rasa-webchat-index-0-0-1.js` for a suffix that corresponds to version `0.0.1`, where the suffix must represent a version bump compared to the latest version available on our Azure Storage account's container (see following point)
+    1. manually upload the renamed file to our Azure Storage account `whoalxppublicstorage` inside the container `machine-learning`
+1. #### Download the Artifacts on the Learner's Browser by Referencing Their URL in Our Front-End Source:
+    1. modify the front-end source of our delivery website so that the widget of Rasa Webchat downloads its source from our Azure Storage account's container, replacing the default URL that points to `cdn.jsdelivr.net` that you can see in the rest of this documentation, as this code snippet exemplifies (make sure to reference to the desired version using the correct suffix):
+        ```diff
+        <script>!(function () {
+          ...
+          (e.src =
+        -    "https://cdn.jsdelivr.net/npm/rasa-webchat@1.x.x/lib/index.js"),
+        +    "https://whoalxppublicstorage.blob.core.windows.net/machine-learning/whoa-rasa-webchat-index-0-0-1.js"),
+          ...
+        })();
+        </script>
+        ```
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $$ \Huge \color{ProcessBlue} WHO \space Academy's \space Customization \space of
           ...
           (e.src =
         -    "https://cdn.jsdelivr.net/npm/rasa-webchat@1.x.x/lib/index.js"),
-        +    "https://whoalxppublicstorage.blob.core.windows.net/machine-learning/whoa-rasa-webchat-index-0-0-1.js"),
+        +    "https://files.lxp.academy.who.int/machine-learning/whoa-rasa-webchat-index-0-0-1.js"),
           ...
         })();
         </script>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,42 @@
+$$ \Huge \color{ProcessBlue} WHO \space Academy's \space Customization \space of \space Rasa \space Webchat $$
+<p align="center">
+    This former part of the documentation explains how integrate this fork with the WHO Academy front end. The remaining part of the documentation is mostly inherited from the original README (and includes the necessary modifications).
+</p>
+
+### How to Integrate This Fork With the WHO Academy Front End
+1. Locally Build the Artifacts Necessary to Run This Customized Library:
+    - have this source on you local
+    - make sure Docker (~ 23.0.5) is installed on your local
+    - in the root folder of the repository, execute:
+      ```
+      docker build --tag whoa-rasa-webchat .
+      docker run --name whoa-rasa-webchat --detach whoa-rasa-webchat
+      docker cp whoa-rasa-webchat:/rasa-webchat/lib/index.js whoa-rasa-webchat-index.js
+      ```
+    - optionally, just to clean your local, also execute in the same folder:
+      ```
+      docker rm -f whoa-rasa-webchat
+      docker rmi whoa-rasa-webchat
+      ```
+2. Upload Such Artifacts From Your Local to Our Azure File Storage Location:
+    - manually upload the newly generated (on your local directory) file `whoa-rasa-webchat-index.js` to our Azure Storage Account `whoalxppublicstorage` inside the container `machine-learning`
+3. Download the Artifacts on the Learner's Browser by Referencing Their URL in Our Front-End Source:
+    - modify the front-end source of our delivery website so that the widget of Rasa Webchat downloads its source from our Azure Storage Account, replacing the default URL that points to `cdn.jsdelivr.net` that you can see in the rest of this documentation, as this code snippet exemplifies:
+      ```diff
+      <script>!(function () {
+        ...
+        (e.src =
+      -    "https://cdn.jsdelivr.net/npm/rasa-webchat@1.x.x/lib/index.js"),
+      +    "https://whoalxppublicstorage.blob.core.windows.net/machine-learning/whoa-rasa-webchat-index.js"),
+        ...
+      })();
+      </script>
+      ```
+
+
+---
+
+
 <p align="center">
 
 <a href="https://www.npmjs.com/package/botfront">

--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ export const rasaWebchatProTypes = {
   socketUrl: PropTypes.string.isRequired,
   socketPath: PropTypes.string,
   protocolOptions: PropTypes.shape({}),
+  jwtToken: PropTypes.string,
   customData: PropTypes.shape({}),
   handleNewUserMessage: PropTypes.func,
   profileAvatar: PropTypes.string,
@@ -179,6 +180,7 @@ export const rasaWebchatProDefaultTypes = {
   protocol: 'socketio',
   socketUrl: 'http://localhost',
   protocolOptions: {},
+  jwtToken: '',
   badge: 0,
   embedded: false,
   params: {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const ConnectedWidget = forwardRef((props, ref) => {
       path,
       protocol,
       protocolOptions,
+      jwtToken,
       onSocketEvent
     ) {
       this.url = url;
@@ -24,6 +25,7 @@ const ConnectedWidget = forwardRef((props, ref) => {
       this.path = path;
       this.protocol = protocol;
       this.protocolOptions = protocolOptions;
+      this.jwtToken = jwtToken;
       this.onSocketEvent = onSocketEvent;
       this.socket = null;
       this.onEvents = [];
@@ -60,7 +62,8 @@ const ConnectedWidget = forwardRef((props, ref) => {
         this.customData,
         this.path,
         this.protocol,
-        this.protocolOptions
+        this.protocolOptions,
+        this.jwtToken
       );
       // We set a function on session_confirm here so as to avoid any race condition
       // this will be called first and will set those parameters for everyone to use.
@@ -91,6 +94,7 @@ const ConnectedWidget = forwardRef((props, ref) => {
       props.socketPath,
       props.protocol,
       props.protocolOptions,
+      props.jwtToken,
       props.onSocketEvent
     );
   }
@@ -169,6 +173,7 @@ ConnectedWidget.propTypes = {
   socketUrl: PropTypes.string.isRequired,
   socketPath: PropTypes.string,
   protocolOptions: PropTypes.shape({}),
+  jwtToken: PropTypes.string,
   customData: PropTypes.shape({}),
   handleNewUserMessage: PropTypes.func,
   profileAvatar: PropTypes.string,
@@ -224,6 +229,7 @@ ConnectedWidget.defaultProps = {
   protocol: 'socketio',
   socketUrl: 'http://localhost',
   protocolOptions: {},
+  jwtToken: '',
   badge: 0,
   embedded: false,
   params: {

--- a/src/socket-socketio.js
+++ b/src/socket-socketio.js
@@ -1,7 +1,14 @@
 import io from 'socket.io-client';
 
-export default function (socketUrl, customData, path) {
-  const options = path ? { path } : {};
+export default function (socketUrl, customData, path, uselessOptions, jwtToken) {
+  const options = {};
+  if (jwtToken) {
+    options.auth = { token: jwtToken };
+  }
+  if (path) {
+    options.path = path;
+  }
+
   const socket = io(socketUrl, options);
   socket.on('connect', () => {
     console.log(`connect:${socket.id}`);

--- a/src/socket-sockjs.js
+++ b/src/socket-sockjs.js
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 /*
   This implementation mimics the SocketIO implementation.
 */
-export default function (socketUrl, customData, _path, options) {
+export default function (socketUrl, customData, _path, options, jwtToken) {
   const socket = SockJS(socketUrl + (_path || ''));
   const stomp = Stomp.over(socket);
 

--- a/src/socket.js
+++ b/src/socket.js
@@ -2,12 +2,12 @@ import socketio from './socket-socketio';
 import sockjs from './socket-sockjs';
 
 const PROTOCOLS = { socketio, sockjs };
-export default function (socketUrl, customData, path, protocol, protocolOptions) {
+export default function (socketUrl, customData, path, protocol, protocolOptions, jwtToken) {
   protocol = protocol || 'socketio';
   const socketProtocol = PROTOCOLS[protocol];
 
   if (socketProtocol !== undefined) {
-    return socketProtocol(socketUrl, customData, path, protocolOptions);
+    return socketProtocol(socketUrl, customData, path, protocolOptions, jwtToken);
   }
   throw new Error(`Undefined socket protocol ${protocol}`);
 }

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -59,7 +59,7 @@ module.exports = [{
       }
     ]
   },
-  plugins: [new CleanWebpackPlugin(['lib'])]
+  plugins: []
 }, {
   entry: './index.js',
   externals: {
@@ -129,6 +129,6 @@ module.exports = [{
       }
     ]
   },
-  plugins: [new CleanWebpackPlugin(['module'])]
+  plugins: []
 }
 ];


### PR DESCRIPTION
## Description

This pull request enables the front end of the delivery website to use this widget (after following the CI instructions on the README) by optionally passing some JWT-based information for Rasa's back end to validate it. In fact, the documentation was updated as well. Moreover, manual versioning for WHOA is introduced in the documentation.


## References

- [to see what the Socket.IO channel of Rasa expects](https://github.com/RasaHQ/rasa/blob/ef5ed2e6aa080829b6c7744baffc0992fb59ca92/rasa/core/channels/socketio.py#L203-L214) (NOTE: we can customize this behavior in our Rasa service)


## How Were Changes Tested?

The artifacts created from this branch's source and by following its README instructions were manually tested by creating and deploying [this branch of the delivery front end](https://github.com/WHOAcademy/learning-experience-platform/compare/dev/bot-cors) which points to [this branch of Rasa with JWT enabled](https://github.com/WHOAcademy/chatbot-rasa/compare/dev/security):
- ### with correctly encoded JWT:
  - #### from the OpenShift deployment of the front-end branch (correct token hardcoded):
    ![immagine](https://github.com/WHOAcademy/rasa-webchat/assets/59971270/d67dfcbd-fa1e-422c-a1a8-00ee766e3fb9)
  - #### from a toy, local front end:
    ![immagine](https://github.com/WHOAcademy/rasa-webchat/assets/59971270/ae33948f-6860-4df3-b567-e9e393d170f4)
- ### with incorrectly encoded JWT:
  - #### from a toy, local front end:
    ![immagine](https://github.com/WHOAcademy/rasa-webchat/assets/59971270/96cdd40f-8c7e-472f-a6f6-c4b7d12686cd)
- ### without JWT:
  - #### from the toy, local front end:
    ![immagine](https://github.com/WHOAcademy/rasa-webchat/assets/59971270/96e3372e-72a2-48c5-9bb2-1e495c1f98d1)


## Build & Deployment

This does not apply, being the CI process manual and the deployment tied to the delivery front end.


- [x] Version Bumped