### PR TITLE
fix: 🪺 behavior of course cards 🪺

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/Carousel/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Carousel/index.js
@@ -20,7 +20,7 @@ const Carousel = (props) => {
 
   const scrollContainer = useRef();
   const [leftButton, setLeftButton] = useState(false);
-  const [rightButton, setRightButton] = useState(true);
+  const [rightButton, setRightButton] = useState(carousel.elements.length > 1);
   const { mainColor, assistTextColor } = useContext(ThemeContext);
 
 

--- a/src/components/Widget/components/Conversation/components/Messages/components/Carousel/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Carousel/index.js
@@ -53,6 +53,7 @@ const Carousel = (props) => {
   };
 
   const { linkTarget } = props;
+  const defaultLinkTarget = '_self';  // instead of '_blank'
 
   return (
     <React.Fragment>
@@ -66,7 +67,7 @@ const Carousel = (props) => {
             <div className="rw-carousel-card" key={index}>
               <a
                 href={defaultActionUrl}
-                target={linkTarget || '_blank'}
+                target={linkTarget || defaultLinkTarget}
                 rel="noopener noreferrer"
                 onClick={() => handleClick(carouselCard.default_action)}
               >
@@ -83,7 +84,7 @@ const Carousel = (props) => {
               <a
                 className="rw-carousel-card-title"
                 href={defaultActionUrl}
-                target={linkTarget || '_blank'}
+                target={linkTarget || defaultLinkTarget}
                 rel="noopener noreferrer"
                 onClick={() => handleClick(carouselCard.default_action)}
                 style={{ color: assistTextColor }}
@@ -93,7 +94,7 @@ const Carousel = (props) => {
               <a
                 className="rw-carousel-card-subtitle"
                 href={defaultActionUrl}
-                target={linkTarget || '_blank'}
+                target={linkTarget || defaultLinkTarget}
                 rel="noopener noreferrer"
                 onClick={() => handleClick(carouselCard.default_action)}
                 style={{ color: assistTextColor }}
@@ -107,7 +108,7 @@ const Carousel = (props) => {
                       <a
                         key={buttonIndex}
                         href={button.url}
-                        target={linkTarget || '_blank'}
+                        target={linkTarget || defaultLinkTarget}
                         rel="noopener noreferrer"
                         className="rw-reply"
                         style={{ borderColor: mainColor, color: mainColor }}


### PR DESCRIPTION
## Description

This pull request introduces changes to course cards required as part of [TTW-1888](https://whoacademy.atlassian.net/browse/TTW-1888), namely:
- courses opening in the same tab when cards clicked (see the issue description)
- right arrow disabled when there is a single course card (see the issue comment(s))


## References

- https://github.com/WHOAcademy/learning-experience-platform/pull/609
- https://github.com/botfront/rasa-webchat/pull/231)


## How Were Changes Tested?

Changes were manually tested with the deployment of https://github.com/WHOAcademy/learning-experience-platform/pull/609 - which makes use of the resulting version of this library:
- ### courses opening in the same tab when cards clicked:
  - #### on main:
    ![immagine](https://github.com/WHOAcademy/learning-experience-platform/assets/59971270/a8d02f34-ea84-4dc3-ac56-d681602e26fe)
    ⬇️ (by clicking on the course card)
    ![immagine](https://github.com/WHOAcademy/learning-experience-platform/assets/59971270/938f9f39-02b8-4ebd-ace3-79aca11e6bf3)
  - #### on this branch:
    ![immagine](https://github.com/WHOAcademy/learning-experience-platform/assets/59971270/95739938-d7a7-4a7c-ab93-0d5b10bf0535)
    ⬇️ (by clicking on the course card)
    ![immagine](https://github.com/WHOAcademy/learning-experience-platform/assets/59971270/ec6645fd-c6e3-4fc3-9e1a-0a3a199cddbd)
- ### right arrow disabled when there is a single course card:
  - #### on main:
    ![immagine](https://github.com/WHOAcademy/learning-experience-platform/assets/59971270/24bc9f2a-5978-46a3-b790-bf1a33cf50db)
  - #### on this branch:
    ![immagine](https://github.com/WHOAcademy/learning-experience-platform/assets/59971270/f8e1c55b-c418-494c-a010-9f8aee34f139)


## Build & Deployment

N/A


- [x] Version Bumped

[TTW-1888]: https://whoacademy.atlassian.net/browse/TTW-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ