### PR TITLE
fix: 🌸 input text freezing on and only on conversation-blocking buttons 🌸

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -31,11 +31,12 @@ import {
   changeOldUrl,
   setDomHighlight,
   evalUrl,
-  setCustomCss
+  setCustomCss,
+  toggleInputDisabled
 } from 'actions';
 import { safeQuerySelectorAll } from 'utils/dom';
 import { SESSION_NAME, NEXT_MESSAGE } from 'constants';
-import { isVideo, isImage, isButtons, isText, isCarousel } from './msgProcessor';
+import { isVideo, isImage, isButtons, isButtonsFreezingInput, isText, isCarousel } from './msgProcessor';
 import WidgetLayout from './layout';
 import { storeLocalSession, getLocalSession } from '../../store/reducers/helper';
 
@@ -568,6 +569,12 @@ class Widget extends Component {
     if (customCss) {
       this.props.dispatch(setCustomCss(message.customCss));
     }
+
+    // either freezing or unfreezing the input text based on whether the
+    // the received message contains conversation-blocking buttons - note that
+    // this way only the latest message received matters, being the one that
+    // dictates the latest state update:
+    this.props.dispatch(toggleInputDisabled(isButtonsFreezingInput(messageClean)));
   }
 
   handleMessageSubmit(event) {

--- a/src/components/Widget/msgProcessor.js
+++ b/src/components/Widget/msgProcessor.js
@@ -30,3 +30,16 @@ export function isButtons(message) {
     && Object.keys(message).includes('text')
     && (Object.keys(message).includes('quick_replies') || Object.keys(message).includes('buttons'));
 }
+
+export function isButtonsFreezingInput(message) {
+  let isThereAnyBlockingButton = false;
+  if (isButtons(message)) {
+    for (const button of message.quick_replies) {
+      if (button.type === 'postback') {
+        isThereAnyBlockingButton = true;
+        break;
+      }
+    }
+  }
+  return isThereAnyBlockingButton;
+}


### PR DESCRIPTION
## Description

This pull request introduces the desired input freezing/unfreezing behavior so that:
- the user can neither enter text nor send messages when buttons to be clicked to continue the conversation (buttons that send responses back to the server) are received
- the user can enter text and send messages when other message kinds or buttons that do not require to be clicked to continue the conversation (buttons opening links) are received


## References

- https://github.com/WHOAcademy/learning-experience-platform/pull/695


## How Were Changes Tested?

Changes were deployed with https://github.com/WHOAcademy/learning-experience-platform/pull/695, which makes use of the resulting version of this library, so refer to that same pull request for test results.


## Build & Deployment

N/A


- [x] Version Bumped